### PR TITLE
统一模板和UI中获取多级命名空间变量的策略

### DIFF
--- a/src/er/context.js
+++ b/src/er/context.js
@@ -97,22 +97,41 @@ er.context = function () {
             var contextId = opt_arg.contextId;
             var value;
             var priv;
-                
+            var i, len;
+            var variable, propName, propLen;
+            var varName  = name.split( /[\.\[]/ );
+            
             if ( 'string' == typeof contextId ) {
                 priv = privateContext[ contextId ];
-                value = priv && priv[ name ];
+                value = priv && priv[ varName[0] ];
             }
             
-            if ( er._util.hasValue( value ) ) {
-                return value;
+            if ( !er._util.hasValue( value ) ) {
+                value = publicContext[ varName[0] ];
             }
-            
-            value = publicContext[ name ];
-            if ( er._util.hasValue( value ) ) {
-                return value;
+            varName.shift();
+
+            for ( i = 0, len = varName.length; i < len; i++ ) {
+                if ( !er._util.hasValue( value ) ) {
+                    break;
+                }
+
+                propName = varName[ i ].replace( /\]$/, '' );
+                propLen  = propName.length;
+                if ( /^(['"])/.test( propName ) 
+                     && propName.lastIndexOf( RegExp.$1 ) == --propLen
+                ) {
+                    propName = propName.slice( 1, propLen );
+                }
+
+                value = value[ propName ];
             }
-    
-            return null;
+
+            if ( !er._util.hasValue( value ) ) {
+                value = null;
+            }
+
+            return value;
         },
 
         /**

--- a/src/er/template.js
+++ b/src/er/template.js
@@ -1161,38 +1161,17 @@ er.template = function () {
      */
     function getVariableValue( scope, varName, opt_filterName ) {
         var typeRule = /:([a-z]+)$/i;
-        var match    = varName.match( typeRule );
-        var value    = '';
-        var i, len;
-        var variable, propName, propLen;
-
+        var match    = name.match( typeRule );
+        var value;
         varName = varName.replace( typeRule, '' );
         if ( match && match.length > 1 ) {
             value = getVariableValueByType( varName, match[1] );
         } else {
-            varName  = varName.split( /[\.\[]/ );
-            variable = scope.get( varName[ 0 ] );
-            varName.shift();
+            value = scope.get(varName);
+        }
 
-            for ( i = 0, len = varName.length; i < len; i++ ) {
-                if ( !er._util.hasValue( variable ) ) {
-                    break;
-                }
-
-                propName = varName[ i ].replace( /\]$/, '' );
-                propLen  = propName.length;
-                if ( /^(['"])/.test( propName ) 
-                     && propName.lastIndexOf( RegExp.$1 ) == --propLen
-                ) {
-                    propName = propName.slice( 1, propLen );
-                }
-
-                variable = variable[ propName ];
-            }
-
-            if ( er._util.hasValue( variable ) ) {
-                value = variable;
-            }
+        if ( value == null ) {
+            value = '';
         }
         
         // 过滤处理

--- a/test/extend_ui.js
+++ b/test/extend_ui.js
@@ -1,7 +1,10 @@
-er.template.parse( '<!-- target: uiview --><div ui="type:Button;id:myButton"></div><div ui="type:Select;id:mySelect;datasource:*users"></div>' );
+er.template.parse( '<!-- target: uiview -->'
+    + '<div ui="type:Button;id:myButton"></div>'
+    + '<div ui="type:Select;id:mySelect;datasource:*users"></div>'
+    + '<div ui="type:Select;id:mySelect2;datasource:*user.list"></div>' );
 er.template.parse( '<!-- target: uiviewsimple --><div ui="type:Button;id:myButton"></div><div ui="type:Select;id:mySelect;"></div>' );
 er.template.parse( '<!-- target: uiinputview --><div ui="type:Button;id:myButton"></div>' 
-    + '<div ui="type:Select;id:mySelect;"></div>' 
+    + '<div ui="type:Select;id:mySelect;"></div>'
     + '<input type="text" ui="type:TextInput;id:myText;value:*textValue"/>'
     + '<span ui="type:Label;id:myLabel"></span>');
 er.template.parse( '<!-- target: uiclear -->just test' );
@@ -42,7 +45,6 @@ var testModule = new er.Module( {
                 path   : '/inputnosilence',
                 action : 'testModule.actionii'  
             }
-
         ]
     }
 } );
@@ -52,6 +54,7 @@ var testUserModel = new er.Model( {
 
     loadUser: new er.Model.Loader( function () {
         this.set( 'users', testUserData );
+        this.set( 'user', { list: testUserData } );
     } )
 } ) ;
 
@@ -149,6 +152,8 @@ test("render repaint & clear", function() {
     same( esui.get('myButton') instanceof esui.Button, true, "button控件被渲染" );
     same( esui.get('mySelect') instanceof esui.Select, true, "select控件被渲染" );
     same( esui.get('mySelect').datasource.length, 3, "*var的方法引用到数据模型" );
+
+    same( esui.get('mySelect2').datasource.length, 3, "使用*引用context变量时可以使用多级命名空间的数据结构。" );
 
     var isRepainted = 0;
     var renderFunc = esui.get('mySelect').render;


### PR DESCRIPTION
2.1模板升级之后，允许使用长命名空间来获取context中复杂数据结构的变量值，但是在UI中如果写`*namespace.variable`却无法获取对应在context中的变量。

为统一两种策略，同时为开发者带来便利，已将原来位于`template.js`中通过命名空间获取变量值的逻辑转移到`context.js`中的`get`函数里实现，并测试达到UI中也可以获取深层context变量的效果。
