### PR TITLE
对选项组增加按值选中功能

### DIFF
--- a/src/esui/BoxGroup.js
+++ b/src/esui/BoxGroup.js
@@ -71,6 +71,33 @@ esui.BoxGroup.prototype = {
     },
     
     /**
+     * 对选项组下所有选项进行按值选中
+     * 
+     * @public
+     * @param {Array} values
+     */
+    selectByValues: function(values) {
+        var boxes   = this.getBoxList(),
+            len     = boxes.length,
+            i       = 0,
+            box,
+            v       = 0,
+            vLen    = values.length;
+        
+        for ( i = 0 ; i < len; i++ ) {
+            box = boxes[i];
+            box.setChecked(false);
+            value = box.getValue();
+            for ( v = 0 ; v < vLen; v++) {
+                if (value == values[v]) {
+                    box.setChecked(true);
+                    break;
+                }
+            }
+        }
+    },
+    
+    /**
      * 对选项组下所有选项进行反选
      * 
      * @public

--- a/test/esui/checkbox_and_radio.html
+++ b/test/esui/checkbox_and_radio.html
@@ -26,27 +26,35 @@ include( 'esui.Button' );// __debug__
 <body>
 <div class="header">[ESUI EXAMPLE] - CheckBox and Radio</div>
 <div class="main">
-	<table cellpadding="5" cellspacing="0" border="0">
-		<tr>
-			<td><input type="checkbox" value="1" ui="type:CheckBox;id:cb1" title="one" name="num"/></td>
-			<td><input type="checkbox" value="2" ui="type:CheckBox;id:cb2" title="two" name="num"/></td>
-			<td><input type="checkbox" value="3" ui="type:CheckBox;id:cb3" title="three" name="num"/></td>
-			<td><div ui="type:Button;id:currCb">当前选中</div></td>
-			<td><div ui="type:Button;id:selAll">全选</div></td>
-			<td><div ui="type:Button;id:selInv">反选</div></td>
-		</tr>
-		<tr>
-			<td><input type="radio" value="1" ui="type:Radio;id:r1" title="one" name="num2"/></td>
-			<td><input type="radio" value="2" ui="type:Radio;id:r2" title="two" name="num2"/></td>
-			<td><input type="radio" value="3" ui="type:Radio;id:r3" title="three" name="num2"/></td>
-			<td colspan="3"><div ui="type:Button;id:currRadio">当前选中</div></td>
-		</tr>
-		<tr>
-			<td><input type="radio" value="1" ui="type:Radio;id:x1" title="one"/></td>
-			<td><input type="checkbox" value="3" ui="type:CheckBox;id:x3" title="three"/></td>
-			<td colspan="3"><div ui="type:Button;id:xRender">Call Render Again</div></td>
-		</tr>
-	</table>
+	<p>
+		<input type="checkbox" value="1" ui="type:CheckBox;id:cb1" title="one" name="num"/>
+		<input type="checkbox" value="2" ui="type:CheckBox;id:cb2" title="two" name="num"/>
+		<input type="checkbox" value="3" ui="type:CheckBox;id:cb3" title="three" name="num"/>
+	</p>
+	<div>
+		<div ui="type:Button;id:currCb">当前选中</div>
+		<div ui="type:Button;id:selAll">全选</div>
+		<div ui="type:Button;id:selInv">反选</div>
+		<div ui="type:Button;id:selValues">选中值为2,3的项</div>
+	</div>
+
+	<p>
+		<input type="radio" value="1" ui="type:Radio;id:r1" title="one" name="num2"/>
+		<input type="radio" value="2" ui="type:Radio;id:r2" title="two" name="num2"/>
+		<input type="radio" value="3" ui="type:Radio;id:r3" title="three" name="num2"/>
+	</p>
+	<div>
+		<div ui="type:Button;id:currRadio">当前选中</div>
+		<div ui="type:Button;id:radioSelValues">选中值为2的项</div>
+	</div>
+
+	<p>
+		<input type="radio" value="1" ui="type:Radio;id:x1" title="one"/>
+		<input type="checkbox" value="3" ui="type:CheckBox;id:x3" title="three"/>
+	</p>
+	<div>
+		<div ui="type:Button;id:xRender">Call Render Again</div>
+	</div>
 </div>
 
 <script>
@@ -66,11 +74,19 @@ esui.get('selInv').onclick = function() {
 	esui.get('cb1').getGroup().selectInverse();
 };
 
+esui.get('selValues').onclick = function () {
+	esui.get('cb1').getGroup().selectByValues([2, 3]);
+};
+
 esui.get('currRadio').onclick = function () {
 	alert( 'checked one:' + esui.get('r1').isChecked() );
 	alert( 'checked two:' + esui.get('r2').isChecked() );
 	alert( 'checked three:' + esui.get('r3').isChecked() );
 	alert( 'group value:' + esui.get('r3').getGroup().getValue() );
+};
+
+esui.get('radioSelValues').onclick = function () {
+	esui.get('r2').getGroup().selectByValues([2]);
 };
 
 esui.get('xRender').onclick = function() {


### PR DESCRIPTION
对`BoxGroup`增加原型方法`selectByValues`，该方法接受一个数组参数，这个数组包含每一个要选中项的值，最后遍历所有值，如果该值在group中有对应选项，则选中该选项，否则取消选中。例：

``` javascript
cbGroup.selectByValues([2, 3]);
```

对于单选组，如果传入包含多值的数组，只会选中数组中最后一个值。
